### PR TITLE
updated common.yaml

### DIFF
--- a/specifications/common.yaml
+++ b/specifications/common.yaml
@@ -1,11 +1,11 @@
 components:
   schemas:
-    description: If the identifier contains spaces or special characters, the entire
-      string must be enclosed in double quotes. Identifiers enclosed in double quotes
-      are also case-sensitive.
     Identifier:
       type: string
-      description: A Snowflake object identifier.
+      description: >
+        A Snowflake object identifier. If the identifier contains spaces or special characters, 
+        the entire string must be enclosed in double quotes. 
+        Identifiers enclosed in double quotes are also case-sensitive.
       pattern: ^"([^"]|"")+"|[a-zA-Z_][a-zA-Z0-9_$]*$
       example: TEST_NAME
     ErrorResponse:
@@ -611,7 +611,3 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
-  security:
-  - KeyPair: []
-  - ExternalOAuth: []
-  - SnowflakeOAuth: []


### PR DESCRIPTION
# Overview

SNOW-XXXXX

This PR fixes structural issues in the `common.yaml` OpenAPI definition that were causing validation and parsing errors in tooling (e.g., StackQL, Swagger).

## Summary of changes

-  **Removed invalid `security` block** from `components` in `common.yaml`. This block belongs at the top level of service specs and caused OpenAPI validation failures.
- **Removed misplaced top-level `description` field** under `components.schemas` in `common.yaml`. This was not a valid key in that context. The content was intended to describe the `Identifier` schema and was appended to its `description` field accordingly.

These changes are schema-only (no functional impact) and are aligned with the OpenAPI 3.0 specification.

## Pre-review checklist

- [ ] This change fixes Jira SNOW-XXXXX
- [x] I attest that this change meets the bar for low risk without security requirements as defined in the [Accelerated Risk Assessment Criteria](https://developer-handbook.m1.us-west-2.aws.app.snowflake.com/docs/reference/security-review/accelerated-risk-assessment/#eligibility) and I have taken the [Risk Assessment Training in Workday](https://wd5.myworkday.com/snowflake/learning/course/6c613806284a1001f111fedf3e4e0000).
- [x] This change has passed precommit
- [x] This change is TEST-ONLY
- [ ] This change has been through a design review process and the test plan is signed off by the owner
- [x] This change is parameter protected *(N/A to spec changes, but leaving checked to indicate no exposed parameters)*
- [x] This change has code coverage for the new code added *(N/A — spec-only update)*
